### PR TITLE
Display raw map name when assets missing

### DIFF
--- a/usermode/src/features/features.cpp
+++ b/usermode/src/features/features.cpp
@@ -18,12 +18,15 @@ void f::run()
 void f::get_map()
 {
 	const auto map_name = i::m_global_vars->m_map_name();
+	m_data["m_map_raw"] = map_name;
+
 	if (map_name.empty() || map_name.find("<empty>") != std::string::npos)
 	{
 		m_data["m_map"] = "invalid";
 
 		LOG_WARNING("failed to get map name! updating m_global_vars");
 		i::m_global_vars = m_memory->read_t<c_global_vars*>(m_memory->find_pattern(CLIENT_DLL, GET_GLOBAL_VARS)->rip().as<c_global_vars*>());
+		return;
 	}
 
 	m_data["m_map"] = map_name;

--- a/webapp/src/app.jsx
+++ b/webapp/src/app.jsx
@@ -34,6 +34,8 @@ const App = () => {
   const [averageLatency, setAverageLatency] = useState(0);
   const [playerArray, setPlayerArray] = useState([]);
   const [mapData, setMapData] = useState();
+  const [mapName, setMapName] = useState();
+  const [rawMapName, setRawMapName] = useState();
   const [localTeam, setLocalTeam] = useState();
   const [bombData, setBombData] = useState();
   const [settings, setSettings] = useState(loadSettings());
@@ -105,12 +107,20 @@ const App = () => {
         setBombData(parsedData.m_bomb);
 
         const map = parsedData.m_map;
+        const mapRaw = parsedData.m_map_raw;
+
+        setMapName(map);
+        setRawMapName(mapRaw);
+
         if (map !== "invalid") {
           setMapData({
             ...(await (await fetch(`data/${map}/data.json`)).json()),
             name: map,
           });
           document.body.style.backgroundImage = `url(./data/${map}/background.png)`;
+        } else {
+          setMapData(undefined);
+          document.body.style.backgroundImage = "";
         }
       };
     };
@@ -195,7 +205,9 @@ const App = () => {
           )) || (
               <div id="radar" className={`relative overflow-hidden origin-center`}>
                 <h1 className="radar_message">
-                  Connected! Waiting for data from usermode
+                  {(mapName === "invalid" &&
+                    `Mapa desconocido${rawMapName ? `: ${rawMapName}` : ""}`) ||
+                    "Connected! Waiting for data from usermode"}
                 </h1>
               </div>
             )}


### PR DESCRIPTION
## Summary
- store the original map string in `m_map_raw` before applying the invalid fallback and stop further processing when the fallback triggers
- keep track of both sanitized and raw map names on the web client so we can avoid fetching assets when the map is invalid
- surface the raw map name in the empty radar message so missing assets show the real map identifier

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cbd63c2bbc8329b211bfb2bb830fbb